### PR TITLE
Add support for sssd_conf manipulation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 ---
-require: rubocop-rspec
+require:
+- rubocop-rspec
+- rubocop-i18n
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: '2.1'
@@ -19,10 +21,12 @@ AllCops:
 Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
+GetText:
+  Enabled: false
 GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
-  - spec/*
+  - spec/**/*
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-dist: trusty
+dist: xenial
 language: ruby
 cache: bundler
 before_install:
@@ -43,12 +43,3 @@ branches:
     - /^v\d/
 notifications:
   email: false
-deploy:
-  provider: puppetforge
-  user: puppet
-  password:
-    secure: ""
-  on:
-    tags: true
-    all_branches: true
-    condition: "$DEPLOY_TO_FORGE = yes"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "jpogran.puppet-vscode",
+    "rebornix.Ruby"
+  ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -17,16 +17,17 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '= 2.0.4',                               require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "json_pure", '<= 2.0.1',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
+  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
@@ -14,8 +15,17 @@ end
 
 def changelog_project
   return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['name']
-  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
+
+  returnVal = nil
+  returnVal ||= begin
+    metadata_source = JSON.load(File.read('metadata.json'))['source']
+    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
+
+    metadata_source_match && metadata_source_match[1]
+  end
+
+  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
+
   puts "GitHubChangelogGenerator project:#{returnVal}"
   returnVal
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: 1.1.x.{build}
 branches:
   only:
     - master
+    - release
 skip_commits:
   message: /^\(?doc\)?.*/
 clone_depth: 10

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,19 @@
+---
+lookup_options:
+    ssh::sshd::trusted_subnets:
+        merge: deep
+    ssh::sshd::config:
+        merge: hash
+    ssh::sshd::config_matches:
+        merge:
+            strategy: deep
+            knockout_prefix: '-'
+    ssh::sshd::revoked_keys:
+        merge: deep
+
+ssh::allow_from::users: []
+ssh::allow_from::groups: []
+
+ssh::sshd::trusted_subnets: []
+ssh::sshd::config_matches: {}
+ssh::sshd::revoked_keys: []

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,6 @@
+---
+ssh::sshd::required_packages:
+  - openssh-server
+ssh::sshd::revoked_keys_file: /etc/ssh/revoked_keys
+ssh::sshd::config:
+    UsePAM: 'yes'

--- a/data/os/RedHat/release.major/7.yaml
+++ b/data/os/RedHat/release.major/7.yaml
@@ -1,0 +1,38 @@
+---
+ssh::sshd::config:
+    AddressFamily: inet
+    ChallengeResponseAuthentication: 'no'
+    Ciphers:
+      - chacha20-poly1305@openssh.com
+      - aes256-gcm@openssh.com
+      - aes256-ctr
+      - aes128-gcm@openssh.com
+      - aes128-ctr
+    ClientAliveCountMax: '4'
+    ClientAliveInterval: '30'
+    Compression: 'yes'
+    DisableForwarding: 'yes'
+    GSSAPIAuthentication: 'no'
+    GSSAPICleanupCredentials: 'no'
+#    GSSAPIKexAlgorithms: gss-group14-sha1-
+    GSSAPIKeyExchange: 'yes'
+    GatewayPorts: 'no'
+    HostKey:
+      - /etc/ssh/ssh_host_ecdsa_key
+      - /etc/ssh/ssh_host_ed25519_key
+      - /etc/ssh/ssh_host_rsa_key
+    KerberosAuthentication: 'no'
+    LogLevel: VERBOSE
+    MACs:
+      - hmac-sha2-512-etm@openssh.com
+      - hmac-sha2-256-etm@openssh.com
+      - umac-128-etm@openssh.com
+      - hmac-sha2-512
+      - hmac-sha2-256
+      - umac-128@openssh.com
+    MaxAuthTries: '2'
+    PasswordAuthentication: 'no'
+    PermitRootLogin: 'no'
+    PubkeyAuthentication: 'no'
+    SyslogFacility: AUTHPRIV
+    UseDNS: 'no'

--- a/data/sshd_all_options.reference
+++ b/data/sshd_all_options.reference
@@ -1,0 +1,181 @@
+---
+ssh::sshd::config:
+    AcceptEnv:
+      - LANG
+      - LANGUAGE
+      - LC_ADDRESS
+      - LC_ALL
+      - LC_COLLATE
+      - LC_CTYPE
+      - LC_IDENTIFICATION
+      - LC_MEASUREMENT
+      - LC_MESSAGES
+      - LC_MONETARY
+      - LC_NAME
+      - LC_NUMERIC
+      - LC_PAPER
+      - LC_TELEPHONE
+      - LC_TIME
+      - XMODIFIERS
+    AddressFamily: inet
+    AllowAgentForwarding: no
+    AllowStreamLocalForwarding: no
+    AllowTcpForwarding: no
+    AuthenticationMethods: any
+    AuthorizedKeysCommand: none
+    AuthorizedKeysCommandUser: none
+
+
+    AuthorizedKeysFile: .ssh/authorized_keys
+    AuthorizedPrincipalsCommand: none
+    AuthorizedPrincipalsCommandUser: none
+    AuthorizedPrincipalsFile: none
+    Banner: none
+    ChallengeResponseAuthentication: no
+    ChrootDirectory: none
+    Ciphers:
+      - chacha20-poly1305@openssh.com
+      - aes256-gcm@openssh.com
+      - aes256-ctr
+      - aes128-gcm@openssh.com
+      - aes128-ctr
+    ClientAliveCountMax: 4
+    ClientAliveInterval: 30
+    Compression: yes
+    DenyGroups: *
+    DenyUsers: *
+    DisableForwarding: yes
+    ExposeAuthenticationMethods: never
+    FingerprintHash: SHA256
+    ForceCommand: none
+    GatewayPorts: no
+    GSSAPIAuthentication: no
+    GSSAPICleanupCredentials: no
+    GSSAPIKeyExchange: no
+    GSSAPIEnablek5users: no
+    GSSAPIStrictAcceptorCheck: yes
+#    GSSAPIStoreCredentialsOnRekey
+    GSSAPIKexAlgorithms: [ gss-group14-sha1- ]
+    HostbasedAcceptedKeyTypes:
+      - ecdsa-sha2-nistp256-cert-v01@openssh.com
+      - ecdsa-sha2-nistp384-cert-v01@openssh.com
+      - ecdsa-sha2-nistp521-cert-v01@openssh.com
+      - ssh-ed25519-cert-v01@openssh.com
+      - ssh-rsa-cert-v01@openssh.com
+      - ssh-dss-cert-v01@openssh.com
+      - ecdsa-sha2-nistp256
+      - ecdsa-sha2-nistp384
+      - ecdsa-sha2-nistp521
+      - ssh-ed25519
+      - rsa-sha2-512
+      - rsa-sha2-256
+      - ssh-rsa
+      - ssh-dss
+    HostbasedAuthentication: no
+    HostbasedUsesNameFromPacketOnly: no
+#HostCertificate
+    HostKey:
+      - /etc/ssh/ssh_host_ecdsa_key
+      - /etc/ssh/ssh_host_ed25519_key
+      - /etc/ssh/ssh_host_rsa_key
+    HostKeyAgent: none
+    HostKeyAlgorithms:
+      - ecdsa-sha2-nistp256-cert-v01@openssh.com
+      - ecdsa-sha2-nistp384-cert-v01@openssh.com
+      - ecdsa-sha2-nistp521-cert-v01@openssh.com
+      - ssh-ed25519-cert-v01@openssh.com
+      - ssh-rsa-cert-v01@openssh.com
+      - ssh-dss-cert-v01@openssh.com
+      - ecdsa-sha2-nistp256
+      - ecdsa-sha2-nistp384
+      - ecdsa-sha2-nistp521
+      - ssh-ed25519
+      - rsa-sha2-512
+      - rsa-sha2-256
+      - ssh-rsa
+      - ssh-dss
+    IgnoreRhosts: yes
+    IgnoreUserKnownHosts: no
+    IPQoS:
+      - lowdelay
+      - throughput
+    KbdInteractiveAuthentication: no
+    KerberosAuthentication: no
+#KerberosGetAFSToken
+#KerberosOrLocalPasswd
+#KerberosTicketCleanup
+#KerberosUseKuserok
+    KexAlgorithms:
+      - curve25519-sha256
+      - curve25519-sha256@libssh.org
+      - ecdh-sha2-nistp256
+      - ecdh-sha2-nistp384
+      - ecdh-sha2-nistp521
+      - diffie-hellman-group-exchange-sha256
+      - diffie-hellman-group16-sha512
+      - diffie-hellman-group18-sha512
+      - diffie-hellman-group-exchange-sha1
+      - diffie-hellman-group14-sha256
+      - diffie-hellman-group14-sha1
+      - diffie-hellman-group1-sha1
+#ListenAddress
+    LoginGraceTime: 60
+    LogLevel: VERBOSE
+    MACs:
+      - hmac-sha2-512-etm@openssh.com
+      - hmac-sha2-256-etm@openssh.com
+      - umac-128-etm@openssh.com
+      - hmac-sha2-512
+      - hmac-sha2-256
+      - umac-128@openssh.com
+#Match
+    MaxAuthTries: 2
+    MaxSessions: 10
+    MaxStartups: 10:30:100
+    PasswordAuthentication: no
+    PermitEmptyPasswords: no
+    PermitOpen: any
+    PermitRootLogin: no
+#    PermitTTY: yes
+    PermitTunnel: no
+#    PermitUserEnvironment: no
+#    PermitUserRC:
+#    PidFile: /var/run/sshd.pid (OS BASED)
+    Port: 22
+#    PrintLastLog: yes
+    PrintMotd: yes
+#    PubkeyAcceptedKeyTypes:
+      - ecdsa-sha2-nistp256-cert-v01@openssh.com
+      - ecdsa-sha2-nistp384-cert-v01@openssh.com
+      - ecdsa-sha2-nistp521-cert-v01@openssh.com
+      - ssh-ed25519-cert-v01@openssh.com
+      - ssh-rsa-cert-v01@openssh.com
+      - ssh-dss-cert-v01@openssh.com
+      - ecdsa-sha2-nistp256
+      - ecdsa-sha2-nistp384
+      - ecdsa-sha2-nistp521
+      - ssh-ed25519
+      - rsa-sha2-512
+      - rsa-sha2-256
+      - ssh-rsa
+      - ssh-dss
+    PubkeyAuthentication: no
+#    RekeyLimit: 0 0
+    RevokedKeys: none
+    ShowPatchLevel: no
+#    StreamLocalBindMask: 0177
+#    StreamLocalBindUnlink: no
+#    StrictModes: yes
+#    Subsystem: sftp /usr/libexec/openssh/sftp-server
+    SyslogFacility: AUTHPRIV
+#    TCPKeepAlive: yes
+    TrustedUserCAKeys: none
+    UseDNS: no
+    UsePAM: no
+    UsePrivilegeSeparation: sandbox
+    VersionAddendum: none
+#    X11DisplayOffset: 10
+#    X11MaxDisplays: 1000
+#    X11Forwarding: no
+#    X11UseLocalhost: yes
+#    XAuthLocation: /usr/bin/xauth (OS BASED?)

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,14 @@
+---
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+hierarchy:
+  - name: "OS Name"
+    path: "os/%{facts.os.family}/name/%{facts.os.name}.yaml"
+  - name: "OS Release"
+    path: "os/%{facts.os.family}/release.major/%{facts.os.release.major}.yaml"
+  - name: "OS Family"
+    path: "os/%{facts.os.family}.yaml"
+  - name: common
+    path: common.yaml

--- a/lib/augeasfacter/sssd_info.conf
+++ b/lib/augeasfacter/sssd_info.conf
@@ -1,0 +1,2 @@
+[sssd_domains]
+path   = /files/etc/sssd/sssd.conf/*[.='sssd']/domains

--- a/manifests/allow_from.pp
+++ b/manifests/allow_from.pp
@@ -5,9 +5,19 @@
 #   + Configures sshd_config with a Match directive and associated parameter
 #     settings
 #
+# @param users
+#   Type: Array
+#   Desc: list of users to allow (from hostlist)
+#   Note: If both "users" and "groups" are empty, error is raised.
+#
+# @param groups
+#   Type: Array
+#   Desc: list of groups to allow (from hostlist)
+#   Note: If both "users" and "groups" are empty, error is raised.
+#
 # @param hostlist
 #   Type: Array
-#   Desc: list of IPs or Hostnames that are allowed to ssh to this node
+#   Desc: list of IPs or Hostnames that (users/groups) are allowed to ssh from
 #
 # @param sshd_cfg_match_params
 #   Type: Hash
@@ -18,36 +28,45 @@
 #                                   }
 #
 # @example
-#   ssh::allow_from { 'comment':
-#       'hostlist'         => Array
-#       'sshd_cfg_match_params' => Hash
+#   ssh::allow_from { 'allow incoming ssh by users 1,2,3 from hosts X,Y,Z':
+#       'users'                 => Array,
+#       'groups'                => Array,
+#       'hostlist'              => Array,
+#       'sshd_cfg_match_params' => Hash,
 #   }
 define ssh::allow_from(
-    Array[ String ]         $pam_access_groups = [],
-    Array[ String ]         $pam_access_users = [],
-    Array[ String, 1 ]      $hostlist,
-    Hash[ String, Data, 1 ] $sshd_cfg_match_params,
+    Array[ String, 1 ]   $hostlist,
+    Array[ String ]      $users                  = [],
+    Array[ String ]      $groups                 = [],
+    Hash[ String, Data ] $sshd_cfg_match_params  = {},
 ) {
 
+    ### CHECK INPUT
+    # one of users or groups must not be empty
+    if empty( $users ) and empty( $groups ) {
+        fail( "'users' and 'groups' cannot both be empty" )
+    }
+
+
     ### ACCESS.CONF
-    # This sets up the pam access.conf file to allow ssh
-    $pam_access_groups.each |String $pam_access_group| { $hostlist.each |String $host| {
-        pam_access::entry { "Allow $pam_access_group ssh from $host":
-            group      => $pam_access_group,
+    ### This sets up the pam access.conf file to allow ssh
+    $groups.each |String $group| { $hostlist.each |String $host| {
+        pam_access::entry { "Allow ${group} ssh from ${host}":
+            group      => $group,
+            origin     => $host,
+            permission => '+',
+            position   => '-1',
+        }
+    }}
+    $users.each |String $user| { $hostlist.each |String $host| {
+        pam_access::entry { "Allow ${user} ssh from ${host}":
+            user       => $user,
             origin     => $host,
             permission => '+',
             position   => '-1',
         }
     }}
 
-    $pam_access_users.each |String $pam_access_user| { $hostlist.each |String $host| {
-        pam_access::entry { "Allow $pam_access_user ssh from $host":
-            user       => $pam_access_user,
-            origin     => $host,
-            permission => '+',
-            position   => '-1',
-        }
-    }}
 
     ### FIREWALL
     $hostlist.each | $host | {
@@ -69,7 +88,33 @@ define ssh::allow_from(
     }
 
 
-    ### SSHD
+    ### SSSD
+    # Requires custom fact 'sssd_domains'
+    # See: lib/augeasfacter/sssd_info.conf
+    # See also: https://github.com/woodsbw/augeasfacter
+    ###
+    # convert sssd domains from csv string to a puppet array
+    $domains = $facts['sssd_domains'].regsubst(/ +/, '', 'G').split(',')
+    $domains.each |$domain| {
+        if $users =~ Array[String,1] {
+            $csv = $users.join(',')
+            ::sssd::domain::array_append { "${name} users '${csv}' for sssd domain '${domain}'" :
+                domain  => $domain,
+                setting => 'simple_allow_users',
+                items   => $users,
+            }
+        }
+        if $groups =~ Array[String,1] {
+            $csv = $groups.join(',')
+            ::sssd::domain::array_append { "${name} groups '${csv}' for sssd domain '${domain}'" :
+                domain  => $domain,
+                setting => 'simple_allow_groups',
+                items   => $groups,
+            }
+        }
+    }
+
+    ### SSHD_CONFIG
     # Defaults
     $config_defaults = {
         'notify' => Service[ sshd ],
@@ -78,7 +123,21 @@ define ssh::allow_from(
         'position' => 'before first match'
     }
 
-    # Hostnames require "Match Host", IPs/CIDRs require "Match Address"
+    # Create cfg_match_params for Users and Groups
+    $user_params = $users ? {
+        Array[ String, 1 ] => { 'AllowUsers' => $users },
+        default            => {}
+    }
+    $group_params = $groups ? {
+        Array[ String, 1 ] => { 'AllowGroups' => $groups },
+        default            => {}
+    }
+
+    # Combine all cfg_match_params into a single hash
+    $cfg_match_params = $sshd_cfg_match_params + $user_params + $group_params
+
+    # Hostnames require "Match Host"
+    # IPs/CIDRs require "Match Address"
     # Create separate lists and make two separate match blocks in sshd_config
     # criteria will be either "Host" or "Address"
     # pattern will be the CSV string of hostnames or IPs
@@ -86,13 +145,14 @@ define ssh::allow_from(
     $name_list = $hostlist.filter | $elem | { $elem =~ /[a-zA-Z]/ }
     $ip_list   = $hostlist.filter | $elem | { $elem !~ /[a-zA-Z]/ }
     #associate the correct criteria with each list, filter empty lists
-    $data = { 'Host'    => $name_list,
-              'Address' => $ip_list,
-            }.filter | $criteria, $list | {
-                size( $list ) > 0
-            }
-    #loop through data creating a match block for each criteria-pattern
-    $data.each | $criteria, $list | {
+    $host_data = {
+        'Host'    => $name_list,
+        'Address' => $ip_list,
+    }.filter | $criteria, $list | {
+        size( $list ) > 0
+    }
+    #loop through host_data creating a match block for each criteria-pattern
+    $host_data.each | $criteria, $list | {
         $pattern = join( $list, ',' )
         $match_condition = "${criteria} ${pattern}"
 
@@ -105,7 +165,7 @@ define ssh::allow_from(
         }
 
         #add parameters to the match block
-        $sshd_cfg_match_params.each | $key, $val | {
+        $cfg_match_params.each | $key, $val | {
             sshd_config {
                 "${match_condition} ${key}" :
                     key       => $key,

--- a/manifests/sshd.pp
+++ b/manifests/sshd.pp
@@ -1,0 +1,133 @@
+# @summary Configure default sshd settings
+#
+# @param trusted_subnets
+#   Array of IPs and CIDRs to be allowed through the firewall
+#   Values from multiple sources are merged
+#
+# @param config
+#   Hash of global config settings
+#   Defaults provided by this module
+#   Values from multiple sources are merged
+#   Key collisions are resolved in favor of the higher priority value
+#
+# @param config_matches
+#   Hash of config "match" conditions and settings
+#   Keys are match condition
+#   Vals are a hash of sshd_config settings for the match condition
+#   Expected format:
+#   ---
+#   stdcfg::sshd::config_matches:
+#     Unique condition one:
+#       SettingOne: val
+#       SettingTwo:
+#         - val2
+#         - val3
+#     Unique condition two:
+#       SettingOne: val
+#       SettingTwo:
+#         - val2
+#         - val3
+#   Note that condition strings must be valid sshd_config criteria-pattern pairs
+#   Values from multiple sources are merged
+#   Key collisions are resolved in favor of the higher priority value
+#   Merges are deep to allow use of the knockout_prefix '-' (to remove a key
+#   from the final result).
+#
+# @param revoked_keys
+#   List of ssh public keys to disallow
+#   Values from multiple sources are merged
+#
+# @note Parameters below here are either OS dependent or not likely to change
+# often
+#
+# @param required_packages
+#   List of package names to be installed (OS specific)
+#   (Defaults provided by module should be sufficient)
+#
+# @example
+#   include ssh::sshd
+class ssh::sshd (
+    Array             $trusted_subnets,
+    Hash              $config,
+    Hash[String,Hash] $config_matches,
+    Array[String]     $revoked_keys,
+
+    # Module defaults should be sufficient
+    Array[String] $required_packages,   #per OS
+    String        $revoked_keys_file,   #per OS
+) {
+
+    # PACKAGES
+    ensure_packages( $required_packages, {'ensure' => 'present'} )
+
+    # SERVICE
+    service { 'sshd' :
+        ensure     => running,
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+        require    => Package[ $required_packages ],
+    }
+
+    # FIREWALL
+    each($trusted_subnets) | $index, $sshd_subnet | {
+        firewall { "022 allow SSH from ${sshd_subnet}":
+            dport  => 22,
+            proto  => tcp,
+            source => $sshd_subnet,
+            action => accept,
+        }
+    }
+
+    # REVOKED KEYS
+    file { $revoked_keys_file :
+        ensure  => present,
+        owner   => root,
+        group   => root,
+        mode    => '0644',
+        content => join( $revoked_keys, "\n" ),
+        notify  => Service['sshd'],
+    }
+
+    # SSHD CONFIG SETTINGS
+
+    # Default sshd_config attributes
+    $config_defaults = {
+        'notify' => Service[ sshd ],
+    }
+    $config_match_defaults = $config_defaults + { 'position' => 'before first match' }
+
+    # Apply global sshd_config settings
+    $config.each | $key, $val | {
+        sshd_config {
+            $key : value => $val,
+            ;
+            default: * => $config_defaults,
+            ;
+        }
+    }
+
+    # Process config match settings from Hiera
+    $config_matches.each | $condition, $data | {
+        # Create config match section
+        sshd_config_match {
+            $condition :
+            ;
+            default: * => $config_match_defaults,
+            ;
+        }
+        # Set each setting inside the match section
+        $data.each | $key, $val | {
+            sshd_config {
+                "${condition} ${key}" :
+                    key       => $key,
+                    value     => $val,
+                    condition => $condition,
+                ;
+                default: * => $config_defaults,
+                ;
+            }
+        }
+    }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,18 @@
   "source": "https://github.com/ncsa/puppet-ssh",
   "project_page": "https://github.com/ncsa/puppet-ssh",
   "dependencies": [
-    { "name": "herculesteam/augeasproviders", "version_requirement": ">= 2.1.3" }
+    {
+      "name": "herculesteam/augeasproviders",
+      "version_requirement": ">= 2.1.3"
+    },
+    {
+      "name": "crayfishx/firewalld",
+      "version_requirement": ">= 3.4.0"
+    },
+    {
+      "name": "MiamiOH/pam_access",
+      "version_requirement": ">= 1.0.1"
+    }
   ],
   "operatingsystem_support": [
     {
@@ -41,7 +52,7 @@
       "version_requirement": ">= 5.0.0 < 6.0.0"
     }
   ],
-  "pdk-version": "1.10.0",
-  "template-url": "file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git#1.10.0",
-  "template-ref": "1.10.0-0-gbba9ac3"
+  "pdk-version": "1.13.0",
+  "template-url": "pdk-default#1.13.0",
+  "template-ref": "1.13.0-0-g66e1443"
 }

--- a/spec/classes/sshd_spec.rb
+++ b/spec/classes/sshd_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'ssh::sshd' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,11 @@ default_fact_files.each do |f|
   end
 end
 
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value
+end
+
 RSpec.configure do |c|
   c.default_facts = default_facts
   c.before :each do
@@ -37,6 +42,8 @@ RSpec.configure do |c|
   end
 end
 
+# Ensures that a module is defined
+# @param module_name Name of the module
 def ensure_module_defined(module_name)
   module_name.split('::').reduce(Object) do |last_module, next_module|
     last_module.const_set(next_module, Module.new) unless last_module.const_defined?(next_module, false)


### PR DESCRIPTION
Summary of changes:
- Add sshd class
- Add support for sssd_conf manipulation from ssh::allow_from
  + Requires [ncsa/puppet-sssd](https://github.com/ncsa/puppet-sssd)
- Add `sssd_domains` custom fact
  + Requires [raphink/puppet-augeasfacter](https://github.com/raphink/puppet-augeasfacter) ... (note: as of this writing, hercules-team version is broken in puppet5)
- Rename allowed_subnets to trusted_subnets
- Rename `pam_access_users` to `users`
- Rename `pam_access_groups` to `groups`
- pdk update to 1.13.0
- Add empty defaults to allow_from